### PR TITLE
Fixed small splash screen icon

### DIFF
--- a/app/src/main/res/drawable/splash_screen_drawable.xml
+++ b/app/src/main/res/drawable/splash_screen_drawable.xml
@@ -9,6 +9,6 @@
     <item>
         <bitmap
             android:gravity="center"
-            android:src="@mipmap/ic_launcher"/>
+            android:src="@drawable/web_hi_res_512"/>
     </item>
 </layer-list>


### PR DESCRIPTION
Earlier the new icon was added but the splash screen img was set to the launcher icon.